### PR TITLE
feat: SQLite-backed REPL history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 🚀 Features
 
+- Add SQLite-backed interactive history with safe connection metadata
 - Infer driver from URI scheme (#29)
 
 ### 📚 Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 🚀 Features
 
-- Add SQLite-backed interactive history with safe connection metadata
+- Add SQLite-backed interactive history with safe connection metadata (#32)
 - Infer driver from URI scheme (#29)
 
 ### 📚 Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown",
+ "hashbrown 0.16.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -422,8 +422,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -468,7 +470,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -603,10 +605,14 @@ dependencies = [
  "arrow-array",
  "arrow-cast",
  "arrow-schema",
+ "chrono",
  "clap",
  "comfy-table",
+ "dirs",
  "nu-ansi-term",
  "reedline",
+ "serde",
+ "serde_json",
  "syntect",
  "tempfile",
  "terminal-colorsaurus",
@@ -640,7 +646,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -673,6 +700,18 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -724,6 +763,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +808,27 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "heck"
@@ -801,7 +867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -812,9 +878,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -913,6 +979,26 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -1063,6 +1149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,17 +1269,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "reedline"
-version = "0.47.0"
+name = "redox_users"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2066729dce9fecd28d1c6850a159ee68719130f149b22467c362353e16994e90"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "reedline"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d010acf9ed312cbc737e5f9064c375a7093975b0c25568337f0c24148f46540d"
 dependencies = [
  "chrono",
  "crossterm",
  "fd-lock",
  "itertools",
  "nu-ansi-term",
+ "rusqlite",
  "serde",
+ "serde_json",
  "strip-ansi-escapes",
  "strum",
  "thiserror",
@@ -1224,6 +1329,31 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
 
 [[package]]
 name = "rustc_version"
@@ -1282,9 +1412,9 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1292,29 +1422,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1394,6 +1524,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "strip-ansi-escapes"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,23 +1552,23 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1434,6 +1576,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1502,22 +1655,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1611,9 +1764,9 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -1626,6 +1779,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1699,7 +1858,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1764,7 +1923,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1775,7 +1934,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1939,7 +2098,7 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,11 @@ arrow-schema = "58.1.0"
 clap = { version = "4.6.1", features = ["derive"] }
 comfy-table = "7.2.2"
 nu-ansi-term = "0.50.3"
-reedline = "0.47.0"
+chrono = "0.4.41"
+dirs = "6.0.0"
+reedline = { version = "0.51.0", features = ["sqlite"] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
 syntect = "5.3.0"
 terminal-colorsaurus = "1.0.3"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -177,11 +177,19 @@ pub fn parse_args() -> AppConfig {
     }
 }
 
+pub(crate) fn uri_driver_scheme(uri: &str) -> Option<&str> {
+    let (scheme, _) = uri.split_once(':')?;
+    let mut chars = scheme.chars();
+    if !chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+        || !chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
+    {
+        return None;
+    }
+    Some(scheme)
+}
+
 fn uri_has_driver_scheme(uri: &str) -> bool {
-    let Some(idx) = uri.find(':') else {
-        return false;
-    };
-    idx != 0
+    uri_driver_scheme(uri).is_some()
 }
 
 fn parse_option(option: &str) -> Result<(String, String), String> {
@@ -258,6 +266,10 @@ mod tests {
         assert!(!uri_has_driver_scheme("plain_path"));
         // Empty scheme (leading colon).
         assert!(!uri_has_driver_scheme(":memory:"));
+        // A scheme must start with an ASCII letter and contain only RFC 3986
+        // scheme characters after it.
+        assert!(!uri_has_driver_scheme("not a scheme://x"));
+        assert!(!uri_has_driver_scheme("duck/db://x"));
     }
 
     #[test]
@@ -265,6 +277,13 @@ mod tests {
         // `profile://` is a valid scheme; `from_uri` resolves it to a profile.
         assert!(uri_has_driver_scheme("profile://my_database"));
         assert!(uri_has_driver_scheme("PROFILE://my_database"));
+    }
+
+    #[test]
+    fn test_uri_driver_scheme_preserves_original_case() {
+        assert_eq!(uri_driver_scheme("DuckDB://x"), Some("DuckDB"));
+        assert_eq!(uri_driver_scheme("sqlite::memory:"), Some("sqlite"));
+        assert_eq!(uri_driver_scheme(":memory:"), None);
     }
 
     #[test]

--- a/src/history.rs
+++ b/src/history.rs
@@ -7,7 +7,7 @@
 //! boundary between reedline's type-erased `History` trait and the typed
 //! SQLite APIs, allowing connection identity to survive a save/load cycle.
 
-use crate::cli::ConnectionSource;
+use crate::cli::{self, ConnectionSource};
 use chrono::Utc;
 use reedline::{
     History, HistoryItem, HistoryItemExtraInfo, HistoryItemId, HistorySessionId, Result,
@@ -40,25 +40,14 @@ impl ConnectionIdentity {
             ConnectionSource::Direct {
                 driver_name, uri, ..
             } => Self::Direct {
-                driver: driver_name
-                    .clone()
-                    .or_else(|| uri.as_deref().and_then(uri_scheme)),
+                driver: driver_name.clone().or_else(|| {
+                    uri.as_deref()
+                        .and_then(cli::uri_driver_scheme)
+                        .map(|scheme| scheme.to_ascii_lowercase())
+                }),
             },
         }
     }
-}
-
-/// Extract only a URI scheme.  The target, user information, and query are
-/// intentionally never retained in history metadata.
-fn uri_scheme(uri: &str) -> Option<String> {
-    let (scheme, _) = uri.split_once(':')?;
-    let mut chars = scheme.chars();
-    if !chars.next().is_some_and(|c| c.is_ascii_alphabetic())
-        || !chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
-    {
-        return None;
-    }
-    Some(scheme.to_ascii_lowercase())
 }
 
 /// Lossless JSON object wrapper for databow history metadata.
@@ -140,8 +129,17 @@ impl HistoryAdapter {
         identity: ConnectionIdentity,
         session: Option<HistorySessionId>,
     ) -> Result<Self> {
+        Self::persistent_at(path, identity, session, Utc::now())
+    }
+
+    fn persistent_at(
+        path: PathBuf,
+        identity: ConnectionIdentity,
+        session: Option<HistorySessionId>,
+        session_timestamp: chrono::DateTime<Utc>,
+    ) -> Result<Self> {
         Ok(Self::new(
-            SqliteBackedHistory::with_file(path, session, Some(Utc::now()))?,
+            SqliteBackedHistory::with_file(path, session, Some(session_timestamp))?,
             identity,
             session,
         ))
@@ -174,7 +172,7 @@ impl HistoryAdapter {
         metadata.set_connection(self.identity.clone());
         HistoryItem {
             id: item.id,
-            start_timestamp: item.start_timestamp,
+            start_timestamp: item.start_timestamp.or_else(|| Some(Utc::now())),
             command_line: item.command_line,
             session_id: item.session_id.or(self.session),
             hostname: item.hostname,
@@ -298,7 +296,8 @@ fn initialize_history_at(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reedline::{History, SearchDirection};
+    use chrono::TimeZone;
+    use reedline::{History, SearchDirection, SearchFilter, SearchQuery};
     use tempfile::tempdir;
 
     fn item(command_line: &str) -> HistoryItem {
@@ -375,16 +374,6 @@ mod tests {
     }
 
     #[test]
-    fn uri_scheme_is_safe_and_normalized() {
-        assert_eq!(
-            uri_scheme("DuckDB://secret/path"),
-            Some("duckdb".to_string())
-        );
-        assert_eq!(uri_scheme(":memory:"), None);
-        assert_eq!(uri_scheme("not a scheme://x"), None);
-    }
-
-    #[test]
     fn unknown_metadata_survives_connection_update() {
         let mut metadata: HistoryExtraInfo =
             serde_json::from_str(r#"{"connection":"future-format","future":{"value":1}}"#).unwrap();
@@ -407,6 +396,7 @@ mod tests {
         let loaded = history.load_with_extra(id).unwrap();
         assert_eq!(loaded.command_line, "select 1");
         assert_eq!(loaded.session_id, session);
+        assert!(loaded.start_timestamp.is_some());
         assert_eq!(
             loaded.more_info.unwrap().connection(),
             Some(profile_identity())
@@ -418,6 +408,72 @@ mod tests {
         assert_eq!(
             loaded.more_info.unwrap().connection(),
             Some(profile_identity())
+        );
+    }
+
+    #[test]
+    fn timestamp_is_filled_without_overwriting_explicit_value() {
+        let mut history = HistoryAdapter::in_memory(profile_identity(), None).unwrap();
+
+        let saved = history.save(item("select 1")).unwrap();
+        assert!(saved.start_timestamp.is_some());
+        assert!(
+            history
+                .load_with_extra(saved.id.unwrap())
+                .unwrap()
+                .start_timestamp
+                .is_some()
+        );
+
+        let explicit = Utc.timestamp_millis_opt(123_456).single().unwrap();
+        let mut explicit_item = item("select 2");
+        explicit_item.start_timestamp = Some(explicit);
+        let explicit_saved = history.save(explicit_item).unwrap();
+        assert_eq!(explicit_saved.start_timestamp, Some(explicit));
+        assert_eq!(
+            history
+                .load_with_extra(explicit_saved.id.unwrap())
+                .unwrap()
+                .start_timestamp,
+            Some(explicit)
+        );
+    }
+
+    #[test]
+    fn timestamped_rows_are_visible_to_a_later_session_cursor() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("history.sqlite3");
+        let session_a = reedline::Reedline::create_history_session_id();
+        let mut history_a =
+            HistoryAdapter::persistent_at(path.clone(), profile_identity(), session_a, Utc::now())
+                .unwrap();
+        let saved = history_a.save(item("select from session_a")).unwrap();
+        let saved_timestamp = saved.start_timestamp.expect("adapter fills timestamp");
+        drop(history_a);
+
+        let session_b = reedline::Reedline::create_history_session_id();
+        let session_b_timestamp = saved_timestamp + chrono::Duration::milliseconds(1);
+        let history_b =
+            HistoryAdapter::persistent_at(path, profile_identity(), session_b, session_b_timestamp)
+                .unwrap();
+        // This is the initial backward query issued by reedline's
+        // HistoryCursor::back for HistoryNavigationQuery::Normal. HistoryCursor
+        // is not re-exported by reedline 0.51, so keep the regression test on
+        // the exact public History query it constructs.
+        let results = history_b
+            .search(SearchQuery {
+                start_id: None,
+                end_id: None,
+                start_time: None,
+                end_time: None,
+                direction: SearchDirection::Backward,
+                limit: Some(1),
+                filter: SearchFilter::anything(session_b),
+            })
+            .unwrap();
+        assert_eq!(
+            results.first().map(|item| item.command_line.as_str()),
+            Some("select from session_a")
         );
     }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,523 @@
+// Copyright 2026 Columnar Technologies Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Persistent interactive history for databow.
+//!
+//! The history database uses reedline's schema directly.  The adapter is the
+//! boundary between reedline's type-erased `History` trait and the typed
+//! SQLite APIs, allowing connection identity to survive a save/load cycle.
+
+use crate::cli::ConnectionSource;
+use chrono::Utc;
+use reedline::{
+    History, HistoryItem, HistoryItemExtraInfo, HistoryItemId, HistorySessionId, Result,
+    SearchQuery, SqliteBackedHistory,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{Map, Value};
+use std::path::PathBuf;
+
+const CONNECTION_KEY: &str = "connection";
+
+/// Safe identity metadata for the connection associated with a history row.
+///
+/// This is deliberately separate from [`ConnectionSource`], which contains
+/// credentials, URI values, and arbitrary driver options needed to connect.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ConnectionIdentity {
+    Profile { profile: String },
+    Direct { driver: Option<String> },
+}
+
+impl ConnectionIdentity {
+    /// Build safe metadata before the connection source is consumed.
+    pub fn from_source(source: &ConnectionSource) -> Self {
+        match source {
+            ConnectionSource::Profile { profile, .. } => Self::Profile {
+                profile: profile.clone(),
+            },
+            ConnectionSource::Direct {
+                driver_name, uri, ..
+            } => Self::Direct {
+                driver: driver_name
+                    .clone()
+                    .or_else(|| uri.as_deref().and_then(uri_scheme)),
+            },
+        }
+    }
+}
+
+/// Extract only a URI scheme.  The target, user information, and query are
+/// intentionally never retained in history metadata.
+fn uri_scheme(uri: &str) -> Option<String> {
+    let (scheme, _) = uri.split_once(':')?;
+    let mut chars = scheme.chars();
+    if !chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+        || !chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
+    {
+        return None;
+    }
+    Some(scheme.to_ascii_lowercase())
+}
+
+/// Lossless JSON object wrapper for databow history metadata.
+///
+/// Known fields are exposed through typed accessors while fields introduced by
+/// newer versions are retained across updates.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct HistoryExtraInfo {
+    fields: Map<String, Value>,
+}
+
+impl HistoryExtraInfo {
+    /// Return the connection identity when the stored value has the known shape.
+    ///
+    /// Keep this accessor available for future history consumers even though
+    /// the initial REPL only writes the identity.
+    #[allow(dead_code)]
+    pub fn connection(&self) -> Option<ConnectionIdentity> {
+        self.fields
+            .get(CONNECTION_KEY)
+            .and_then(|value| serde_json::from_value(value.clone()).ok())
+    }
+
+    pub fn set_connection(&mut self, identity: ConnectionIdentity) {
+        self.fields.insert(
+            CONNECTION_KEY.to_string(),
+            serde_json::to_value(identity).expect("connection identity is serializable"),
+        );
+    }
+}
+
+impl Serialize for HistoryExtraInfo {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.fields.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for HistoryExtraInfo {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match Value::deserialize(deserializer)? {
+            Value::Object(fields) => Ok(Self { fields }),
+            value => Err(serde::de::Error::custom(format!(
+                "history metadata must be a JSON object, got {value}"
+            ))),
+        }
+    }
+}
+
+impl HistoryItemExtraInfo for HistoryExtraInfo {}
+
+/// A small adapter that adds connection identity to reedline history saves.
+pub struct HistoryAdapter {
+    backend: SqliteBackedHistory,
+    identity: ConnectionIdentity,
+    session: Option<HistorySessionId>,
+}
+
+impl HistoryAdapter {
+    fn new(
+        backend: SqliteBackedHistory,
+        identity: ConnectionIdentity,
+        session: Option<HistorySessionId>,
+    ) -> Self {
+        Self {
+            backend,
+            identity,
+            session,
+        }
+    }
+
+    pub fn persistent(
+        path: PathBuf,
+        identity: ConnectionIdentity,
+        session: Option<HistorySessionId>,
+    ) -> Result<Self> {
+        Ok(Self::new(
+            SqliteBackedHistory::with_file(path, session, Some(Utc::now()))?,
+            identity,
+            session,
+        ))
+    }
+
+    pub fn in_memory(
+        identity: ConnectionIdentity,
+        session: Option<HistorySessionId>,
+    ) -> Result<Self> {
+        Ok(Self::new(
+            SqliteBackedHistory::in_memory()?,
+            identity,
+            session,
+        ))
+    }
+
+    /// Access the typed backend for tests and future metadata operations.
+    #[cfg(test)]
+    pub fn load_with_extra(&self, id: HistoryItemId) -> Result<HistoryItem<HistoryExtraInfo>> {
+        self.backend.load_with_extra(id)
+    }
+
+    fn typed_item(&self, item: HistoryItem) -> HistoryItem<HistoryExtraInfo> {
+        let existing: HistoryExtraInfo = item
+            .id
+            .and_then(|id| self.backend.load_with_extra(id).ok())
+            .and_then(|loaded| loaded.more_info)
+            .unwrap_or_default();
+        let mut metadata = existing;
+        metadata.set_connection(self.identity.clone());
+        HistoryItem {
+            id: item.id,
+            start_timestamp: item.start_timestamp,
+            command_line: item.command_line,
+            session_id: item.session_id.or(self.session),
+            hostname: item.hostname,
+            cwd: item.cwd,
+            duration: item.duration,
+            exit_status: item.exit_status,
+            more_info: Some(metadata),
+        }
+    }
+}
+
+fn erase_extra(item: HistoryItem<HistoryExtraInfo>) -> HistoryItem {
+    HistoryItem {
+        id: item.id,
+        start_timestamp: item.start_timestamp,
+        command_line: item.command_line,
+        session_id: item.session_id,
+        hostname: item.hostname,
+        cwd: item.cwd,
+        duration: item.duration,
+        exit_status: item.exit_status,
+        more_info: None,
+    }
+}
+
+impl History for HistoryAdapter {
+    fn save(&mut self, item: HistoryItem) -> Result<HistoryItem> {
+        let original = item.clone();
+        match self.backend.save_with_extra(self.typed_item(item)) {
+            Ok(saved) => Ok(erase_extra(saved)),
+            Err(error) => {
+                // Reedline currently expects save to succeed and panics on an
+                // error. Keep the REPL usable when persistent history fails.
+                eprintln!("Warning: failed to save databow history: {error:?}");
+                Ok(original)
+            }
+        }
+    }
+
+    fn load(&self, id: HistoryItemId) -> Result<HistoryItem> {
+        self.backend.load(id)
+    }
+
+    fn count(&self, query: SearchQuery) -> Result<i64> {
+        self.backend.count(query)
+    }
+
+    fn search(&self, query: SearchQuery) -> Result<Vec<HistoryItem>> {
+        self.backend.search(query)
+    }
+
+    fn update(
+        &mut self,
+        id: HistoryItemId,
+        updater: &dyn Fn(HistoryItem) -> HistoryItem,
+    ) -> Result<()> {
+        // reedline 0.51 preserves typed more_info on this type-erased path.
+        self.backend.update(id, updater)
+    }
+
+    fn clear(&mut self) -> Result<()> {
+        self.backend.clear()
+    }
+
+    fn delete(&mut self, id: HistoryItemId) -> Result<()> {
+        self.backend.delete(id)
+    }
+
+    fn sync(&mut self) -> std::io::Result<()> {
+        self.backend.sync()
+    }
+
+    fn session(&self) -> Option<HistorySessionId> {
+        self.session
+    }
+}
+
+/// Resolve the default OS-appropriate application data directory.
+pub fn default_history_path() -> Option<PathBuf> {
+    dirs::data_dir().map(|path| path.join("databow").join("history.sqlite3"))
+}
+
+/// Open persistent history, falling back to an in-memory SQLite backend.
+pub fn initialize_history(
+    identity: ConnectionIdentity,
+    session: Option<HistorySessionId>,
+) -> Box<dyn History> {
+    initialize_history_at(default_history_path(), identity, session)
+}
+
+fn initialize_history_at(
+    path: Option<PathBuf>,
+    identity: ConnectionIdentity,
+    session: Option<HistorySessionId>,
+) -> Box<dyn History> {
+    if let Some(path) = path {
+        match HistoryAdapter::persistent(path.clone(), identity.clone(), session) {
+            Ok(history) => return Box::new(history),
+            Err(error) => eprintln!(
+                "Warning: failed to initialize persistent databow history at {}: {error:?}; using in-memory history",
+                path.display()
+            ),
+        }
+    } else {
+        eprintln!(
+            "Warning: could not resolve a databow history directory; using in-memory history"
+        );
+    }
+
+    match HistoryAdapter::in_memory(identity, session) {
+        Ok(history) => Box::new(history),
+        Err(error) => {
+            eprintln!("Warning: failed to initialize in-memory databow history: {error:?}");
+            // A backend failure is extraordinarily unlikely, but the REPL can
+            // still operate with reedline's default in-memory implementation.
+            Box::new(reedline::FileBackedHistory::default())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reedline::{History, SearchDirection};
+    use tempfile::tempdir;
+
+    fn item(command_line: &str) -> HistoryItem {
+        HistoryItem::from_command_line(command_line)
+    }
+
+    fn profile_identity() -> ConnectionIdentity {
+        ConnectionIdentity::Profile {
+            profile: "production".to_string(),
+        }
+    }
+
+    #[test]
+    fn identity_excludes_credentials_options_and_uri_target() {
+        let source = ConnectionSource::Direct {
+            driver_name: None,
+            uri: Some("postgresql://user:password@example/db?token=secret".to_string()),
+            username: Some("user".to_string()),
+            password: Some("password".to_string()),
+            options: vec![("token".to_string(), "secret".to_string())],
+        };
+        let identity = ConnectionIdentity::from_source(&source);
+        assert_eq!(
+            identity,
+            ConnectionIdentity::Direct {
+                driver: Some("postgresql".to_string())
+            }
+        );
+        let json = serde_json::to_string(&identity).unwrap();
+        assert!(!json.contains("password"));
+        assert!(!json.contains("secret"));
+        assert!(!json.contains("example"));
+    }
+
+    #[test]
+    fn direct_identity_is_persisted_without_sensitive_fields() {
+        let source = ConnectionSource::Direct {
+            driver_name: None,
+            uri: Some("postgresql://user:password@example/db?token=secret".to_string()),
+            username: Some("user".to_string()),
+            password: Some("password".to_string()),
+            options: vec![("token".to_string(), "secret".to_string())],
+        };
+        let identity = ConnectionIdentity::from_source(&source);
+        let dir = tempdir().unwrap();
+        let mut history =
+            HistoryAdapter::persistent(dir.path().join("history.sqlite3"), identity, None).unwrap();
+        let id = history.save(item("select 1")).unwrap().id.unwrap();
+        let metadata = history.load_with_extra(id).unwrap().more_info.unwrap();
+        let json = serde_json::to_value(metadata).unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "connection": {"kind": "direct", "driver": "postgresql"}
+            })
+        );
+        let serialized = json.to_string();
+        assert!(!serialized.contains("password"));
+        assert!(!serialized.contains("secret"));
+        assert!(!serialized.contains("example"));
+    }
+
+    #[test]
+    fn profile_identity_stores_only_user_profile() {
+        let source = ConnectionSource::Profile {
+            profile: "production".to_string(),
+            uri: Some("postgresql://user:password@host/db".to_string()),
+            username: Some("user".to_string()),
+            password: Some("password".to_string()),
+            options: vec![("secret".to_string(), "value".to_string())],
+        };
+        assert_eq!(ConnectionIdentity::from_source(&source), profile_identity());
+    }
+
+    #[test]
+    fn uri_scheme_is_safe_and_normalized() {
+        assert_eq!(
+            uri_scheme("DuckDB://secret/path"),
+            Some("duckdb".to_string())
+        );
+        assert_eq!(uri_scheme(":memory:"), None);
+        assert_eq!(uri_scheme("not a scheme://x"), None);
+    }
+
+    #[test]
+    fn unknown_metadata_survives_connection_update() {
+        let mut metadata: HistoryExtraInfo =
+            serde_json::from_str(r#"{"connection":"future-format","future":{"value":1}}"#).unwrap();
+        assert!(metadata.connection().is_none());
+        metadata.set_connection(profile_identity());
+        let value: Value = serde_json::to_value(metadata).unwrap();
+        assert_eq!(value["future"]["value"], 1);
+        assert_eq!(value["connection"]["kind"], "profile");
+    }
+
+    #[test]
+    fn sqlite_history_round_trips_typed_connection_metadata() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("history.sqlite3");
+        let session = reedline::Reedline::create_history_session_id();
+        let mut history =
+            HistoryAdapter::persistent(path.clone(), profile_identity(), session).unwrap();
+        let saved = history.save(item("select 1")).unwrap();
+        let id = saved.id.unwrap();
+        let loaded = history.load_with_extra(id).unwrap();
+        assert_eq!(loaded.command_line, "select 1");
+        assert_eq!(loaded.session_id, session);
+        assert_eq!(
+            loaded.more_info.unwrap().connection(),
+            Some(profile_identity())
+        );
+        drop(history);
+
+        let reopened = HistoryAdapter::persistent(path, profile_identity(), session).unwrap();
+        let loaded = reopened.load_with_extra(id).unwrap();
+        assert_eq!(
+            loaded.more_info.unwrap().connection(),
+            Some(profile_identity())
+        );
+    }
+
+    #[test]
+    fn multiple_saves_share_one_session() {
+        let session = reedline::Reedline::create_history_session_id();
+        let mut history = HistoryAdapter::in_memory(profile_identity(), session).unwrap();
+        let first = history.save(item("select 1")).unwrap();
+        let second = history.save(item("select 2")).unwrap();
+        assert_eq!(first.session_id, session);
+        assert_eq!(second.session_id, session);
+        assert_eq!(history.session(), session);
+        let query = SearchQuery::everything(SearchDirection::Forward, session);
+        assert_eq!(history.count(query).unwrap(), 2);
+    }
+
+    #[test]
+    fn persistent_open_failure_falls_back_to_memory() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("existing-directory");
+        std::fs::create_dir(&path).unwrap();
+        let session = reedline::Reedline::create_history_session_id();
+        let mut history = initialize_history_at(Some(path), profile_identity(), session);
+        let saved = history.save(item("select 1")).unwrap();
+        assert!(saved.id.is_some());
+        assert_eq!(saved.session_id, session);
+        assert_eq!(history.session(), session);
+        assert_eq!(history.count_all().unwrap(), 1);
+    }
+
+    #[test]
+    fn default_history_path_has_expected_application_shape() {
+        let Some(path) = default_history_path() else {
+            return;
+        };
+        assert_eq!(
+            path.file_name(),
+            Some(std::ffi::OsStr::new("history.sqlite3"))
+        );
+        assert_eq!(
+            path.parent().and_then(std::path::Path::file_name),
+            Some(std::ffi::OsStr::new("databow"))
+        );
+    }
+
+    #[test]
+    fn type_erased_update_preserves_more_info() {
+        let dir = tempdir().unwrap();
+        let mut history = HistoryAdapter::persistent(
+            dir.path().join("history.sqlite3"),
+            profile_identity(),
+            None,
+        )
+        .unwrap();
+        let id = history.save(item("select 1")).unwrap().id.unwrap();
+        history
+            .update(id, &|mut item| {
+                item.command_line = "select 2".to_string();
+                item
+            })
+            .unwrap();
+        let loaded = history.load_with_extra(id).unwrap();
+        assert_eq!(loaded.command_line, "select 2");
+        assert_eq!(
+            loaded.more_info.unwrap().connection(),
+            Some(profile_identity())
+        );
+    }
+
+    #[test]
+    fn saving_an_existing_item_preserves_unknown_metadata() {
+        let dir = tempdir().unwrap();
+        let mut history = HistoryAdapter::persistent(
+            dir.path().join("history.sqlite3"),
+            profile_identity(),
+            None,
+        )
+        .unwrap();
+        let id = history.save(item("select 1")).unwrap().id.unwrap();
+        history
+            .backend
+            .update_with_extra::<HistoryExtraInfo>(id, &|mut item| {
+                item.more_info.as_mut().unwrap().fields.insert(
+                    "future_field".to_string(),
+                    Value::String("preserve me".to_string()),
+                );
+                item
+            })
+            .unwrap();
+
+        let mut updated = history.load(id).unwrap();
+        updated.command_line = "select 2".to_string();
+        history.save(updated).unwrap();
+
+        let loaded = history.load_with_extra(id).unwrap();
+        let metadata = loaded.more_info.unwrap();
+        assert_eq!(
+            metadata.fields.get("future_field"),
+            Some(&Value::String("preserve me".to_string()))
+        );
+        assert_eq!(metadata.connection(), Some(profile_identity()));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 mod cli;
 mod database;
 mod highlighter;
+mod history;
 mod output;
 mod repl;
 mod table;
@@ -21,11 +22,12 @@ fn main() {
     } = parse_args();
 
     if matches!(query_source, QuerySource::Interactive) {
+        let connection_identity = history::ConnectionIdentity::from_source(&connection);
         let connection = database::initialize_connection(connection).unwrap_or_else(|e| {
             eprintln!("{e}");
             exit(1);
         });
-        repl::run_repl(connection, table_mode);
+        repl::run_repl(connection, table_mode, connection_identity);
         return;
     }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -3,6 +3,7 @@
 
 use crate::database;
 use crate::highlighter::SyntectHighlighter;
+use crate::history::{self, ConnectionIdentity};
 use crate::table::{TableMode, print_batches};
 use adbc_core::Connection;
 use reedline::{
@@ -50,10 +51,20 @@ impl Prompt for SqlPrompt {
     }
 }
 
-pub fn run_repl(mut connection: impl Connection, table_mode: TableMode) {
+pub fn run_repl(
+    mut connection: impl Connection,
+    table_mode: TableMode,
+    connection_identity: ConnectionIdentity,
+) {
+    let history_session = Reedline::create_history_session_id();
     let mut line_editor = Reedline::create()
         .with_highlighter(Box::new(SyntectHighlighter::new()))
-        .with_validator(Box::new(SqlValidator));
+        .with_validator(Box::new(SqlValidator))
+        .with_history_session_id(history_session)
+        .with_history(history::initialize_history(
+            connection_identity,
+            history_session,
+        ));
     let prompt = SqlPrompt;
     let mut ctrl_c_count: u8 = 0;
 


### PR DESCRIPTION
Fix #16

Add SQLite-backed cross-session REPL history using reedline 0.51.0, with platform data-directory persistence and an in-memory fallback.

Each entry also stores a credential-safe connection identity in `more_info`.
This metadata is not used for filtering yet, but may support future connection or directory scoped history settings when databow gains a general application configuration file.